### PR TITLE
Always show the formspec of captcha first.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,6 +3,7 @@ allow_defined_top = true
 
 globals = {
     "minetest",
+    "minenews",
     "ranks",
 }
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,4 @@
 name = minecaptcha
-description = Requires a captcha solution to grant shout and interact privs
+title = MineCaptcha
+description = Requires a captcha solution for players to join or create new accounts
+optional_depends = minenews, ranks

--- a/scripts/minetest.conf
+++ b/scripts/minetest.conf
@@ -16,3 +16,4 @@ minecaptcha.on_newplayer_remove_accounts = true
 minecaptcha.privs_on_success = interact,shout,basic_privs
 minecaptcha.enable_ban = false
 minecaptcha.bypass_users = ronoaldo
+minecaptcha.time_limit = 15

--- a/scripts/testserver.sh
+++ b/scripts/testserver.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-minetest --server --config scripts/minetest.conf --verbose --worldname MineCaptchaDev
+minetest --server --config scripts/minetest.conf --verbose --worldname MineCaptchaDev 2>&1 | grep -E 'ACTION|minecaptcha'


### PR DESCRIPTION
Also fixes a server crash if time_limit is used,
and player is no longer connected.

Fixes #1